### PR TITLE
fix: downgrade cacheable lookup to avoid dynamic imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@bitfinex/bfx-facs-http",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitfinex/bfx-facs-http",
-      "version": "1.0.1",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bitfinex/bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git",
         "async": "^2.6.3",
-        "cacheable-lookup": "7.0.0",
+        "cacheable-lookup": "6.1.0",
         "lodash": "^4.17.21",
         "node-fetch": "2.6.7"
       },
@@ -1262,11 +1262,11 @@
       }
     },
     "node_modules/cacheable-lookup": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz",
+      "integrity": "sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=10.6.0"
       }
     },
     "node_modules/caching-transform": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfinex/bfx-facs-http",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Bitfinex HTTP Facility",
   "author": "vigan.abd",
   "keywords": [
@@ -18,7 +18,7 @@
   "dependencies": {
     "@bitfinex/bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git",
     "async": "^2.6.3",
-    "cacheable-lookup": "7.0.0",
+    "cacheable-lookup": "6.1.0",
     "lodash": "^4.17.21",
     "node-fetch": "2.6.7"
   },

--- a/src/http.facility.js
+++ b/src/http.facility.js
@@ -7,6 +7,7 @@ const fetch = require('node-fetch')
 const HttpError = require('./http.error')
 const { Agent: HttpsAgent } = require('https')
 const { Agent: HttpAgent } = require('http')
+const CacheableLookup = require('cacheable-lookup')
 
 class HttpFacility extends Base {
   constructor (caller, opts, ctx) {
@@ -26,8 +27,7 @@ class HttpFacility extends Base {
         this.abortTimeout = this.opts.abortTimeout || 0
         this.debug = !!this.opts.debug
         this.qs = this.opts.qs ? new URLSearchParams(this.opts.qs).toString() : ''
-        const CachableLookup = (await import('cacheable-lookup')).default
-        this.cachableLookup = new CachableLookup()
+        this.cacheableLookup = new CacheableLookup()
       }
     ], cb)
   }
@@ -105,7 +105,7 @@ class HttpFacility extends Base {
         const Agent = ((this.baseUrl ?? '').startsWith('https://') || path.startsWith('https://')) ? HttpsAgent : HttpAgent
         reqOpts.agent = new Agent({
           keepAlive: true,
-          lookup: this.cachableLookup.lookup
+          lookup: this.cacheableLookup.lookup
         })
       }
 

--- a/test/http.facility.test.js
+++ b/test/http.facility.test.js
@@ -14,26 +14,34 @@ const { expect } = chai.use(require('dirty-chai'))
   .use(require('chai-as-promised'))
 const { format } = require('util')
 const { join } = require('path')
-const { lookup } = require('node:dns')
+const CacheableLookup = require('cacheable-lookup')
 
 describe('http facility tests', () => {
   let srv = null
   const app = express()
   let fac = new HttpFacility({}, { baseUrl: 'http://127.0.0.1:7070' }, { env: 'test' })
+  let sockets
 
   before((done) => {
+    sockets = new Set()
     fac.start((err) => {
       if (err) return done(err)
 
       app.use(express.json())
-      srv = app.listen(7070)
-      done()
+      srv = app.listen(7070, () => {
+        srv.on('connection', (socket) => {
+          sockets.add(socket)
+          socket.on('close', () => sockets.delete(socket))
+        })
+        done()
+      })
     })
   })
 
   after((done) => {
     fac.stop((err) => {
       if (err) return done(err)
+      for (const socket of sockets) socket.destroy()
       srv.close(done)
     })
   })
@@ -414,28 +422,28 @@ describe('http facility tests', () => {
 
     describe('DNS caching', () => {
       beforeEach(() => {
-        fac.cachableLookup._cache.clear()
+        fac.cacheableLookup._cache.clear()
         fac.opts.dnsCaching = false
       })
 
       it('should not perform dns caching by default', async () => {
         await fac.request('https://example.com', { method: 'get', timeout: 1000 })
 
-        expect(fac.cachableLookup._cache.get('example.com')).to.deep.eq(undefined)
+        expect(fac.cacheableLookup._cache.get('example.com')).to.deep.eq(undefined)
       })
 
       it('should support dns caching for https requests', async () => {
         await fac.request('https://example.com', { method: 'get', timeout: 1000, dnsCaching: true })
 
         const expectedAddress = await lookupDomain('example.com')
-        expect(fac.cachableLookup._cache.get('example.com').some(e => e.address === expectedAddress)).to.be.true()
+        expect(fac.cacheableLookup._cache.get('example.com').some(e => e.address === expectedAddress)).to.be.true()
       })
 
       it('should support dns caching for http requests', async () => {
         await fac.request('http://example.com', { method: 'get', timeout: 1000, dnsCaching: true })
 
         const expectedAddress = await lookupDomain('example.com')
-        expect(fac.cachableLookup._cache.get('example.com').some(e => e.address === expectedAddress)).to.be.true()
+        expect(fac.cacheableLookup._cache.get('example.com').some(e => e.address === expectedAddress)).to.be.true()
       })
 
       it('can be activated by default through fac opts', async () => {
@@ -444,15 +452,13 @@ describe('http facility tests', () => {
         await fac.request('https://example.com', { method: 'get', timeout: 1000 })
 
         const expectedAddress = await lookupDomain('example.com')
-        expect(fac.cachableLookup._cache.get('example.com').some(e => e.address === expectedAddress)).to.be.true()
+        expect(fac.cacheableLookup._cache.get('example.com').some(e => e.address === expectedAddress)).to.be.true()
       })
 
-      const lookupDomain = async (domain) => new Promise((resolve, reject) => {
-        lookup(domain, null, (err, address) => {
-          if (err) return reject(err)
-          resolve(address)
-        })
-      })
+      const lookupDomain = async (domain) => {
+        const entry = await (new CacheableLookup()).lookupAsync(domain)
+        return entry.address
+      }
     })
   })
 


### PR DESCRIPTION
# Asana Task

[Enable DNS caching for analytics](https://app.asana.com/1/29923630752984/project/1201889891323175/task/1214359293599253?focus=true)

# Description

- downgrade cacheable-lookup to version 6 so we can avoid dynamic imports
- improved tests so it closes keep-alive sockets before closing the server